### PR TITLE
Updated sdk version in tutorial to latest version.

### DIFF
--- a/doc-source-md/development-frameworks/mapbox_android.md
+++ b/doc-source-md/development-frameworks/mapbox_android.md
@@ -30,7 +30,7 @@ repositories {
 }
  
 dependencies {
-    implementation 'com.mapcat.mapcatsdk:mapcat-android-sdk:1.0.1'
+    implementation 'com.mapcat.mapcatsdk:mapcat-android-sdk:1.0.4'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-services:2.2.9'
 }
 ```


### PR DESCRIPTION
Just released the 1.0.4 version of the sdk. It soon will be online in maven central.
Updated tutorial so it uses the latest version.